### PR TITLE
Fix API key validation bug

### DIFF
--- a/packages/server/src/utils/apiKey.ts
+++ b/packages/server/src/utils/apiKey.ts
@@ -41,6 +41,9 @@ export const generateSecretHash = (apiKey: string): string => {
  * @returns {boolean}
  */
 export const compareKeys = (storedKey: string, suppliedKey: string): boolean => {
+    if (!storedKey || !suppliedKey) {
+        return false
+    }
     const [hashedPassword, salt] = storedKey.split('.')
     const buffer = scryptSync(suppliedKey, salt, 64) as Buffer
     return timingSafeEqual(Buffer.from(hashedPassword, 'hex'), buffer)

--- a/packages/server/src/utils/validateKey.ts
+++ b/packages/server/src/utils/validateKey.ts
@@ -19,6 +19,7 @@ export const validateChatflowAPIKey = async (req: Request, chatflow: ChatFlow) =
     if (suppliedKey) {
         const keys = await apikeyService.getAllApiKeys()
         const apiSecret = keys.find((key: any) => key.id === chatFlowApiKeyId)?.apiSecret
+        if (!apiSecret) return false
         if (!compareKeys(apiSecret, suppliedKey)) return false
         return true
     }


### PR DESCRIPTION
## Summary
- avoid throwing when comparing invalid keys
- check for missing API key secret when validating chatflow keys

## Testing
- `npx prettier -w packages/server/src/utils/apiKey.ts packages/server/src/utils/validateKey.ts`